### PR TITLE
vm: Pass uuid from DM commandline to vm as GUID.

### DIFF
--- a/include/vmmapi.h
+++ b/include/vmmapi.h
@@ -30,6 +30,7 @@
 #define	_VMMAPI_H_
 
 #include <sys/param.h>
+#include <uuid/uuid.h>
 #include "types.h"
 #include "vmm.h"
 
@@ -52,6 +53,7 @@ struct vmctx {
 	char    *mmap_highmem;
 	char    *baseaddr;
 	char    *name;
+	uuid_t	vm_uuid;
 };
 
 /*


### PR DESCRIPTION
Also save the uuid to ctx in case DM needs to access the
uuid.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>