### PR TITLE
DM: fix build error with gcc-8.

### DIFF
--- a/hw/acpi/acpi.c
+++ b/hw/acpi/acpi.c
@@ -921,7 +921,7 @@ basl_make_templates(void)
 			len--;
 		basl_template[len] = '/';
 		strncpy(&basl_template[len + 1], ASL_TEMPLATE,
-					sizeof(ASL_TEMPLATE));
+					MAXPATHLEN - len - 1);
 	} else
 		err = -1;
 
@@ -934,10 +934,10 @@ basl_make_templates(void)
 			strncpy(basl_stemplate, tmpdir, len);
 			basl_stemplate[len] = '/';
 			strncpy(&basl_stemplate[len + 1], ASL_TEMPLATE,
-					sizeof(ASL_TEMPLATE));
+					MAXPATHLEN - len - 1);
 			len += sizeof(ASL_TEMPLATE);
 			strncpy(&basl_stemplate[len], ASL_SUFFIX,
-					sizeof(ASL_SUFFIX));
+					sizeof(ASL_TEMPLATE));
 		} else
 			err = -1;
 	}


### PR DESCRIPTION
gcc8 showed following errors when build DM:
  error: argument to ‘sizeof’ in ‘strncpy’ call is the same
  expression as the source; did you mean to use the size of the
  destination? [-Werror=sizeof-pointer-memaccess]

It looks like wrong parameter was given to strncpy.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>