### PR TITLE
DM: Add long option to enable trusty

### DIFF
--- a/core/main.c
+++ b/core/main.c
@@ -74,6 +74,7 @@ char *vmname;
 int guest_ncpus;
 char *guest_uuid_str;
 char *vsbl_file_name;
+uint8_t trusty_enabled;
 bool stdio_in_use;
 
 static int guest_vmexit_on_hlt, guest_vmexit_on_pause;
@@ -129,7 +130,7 @@ usage(int code)
 		"Usage: %s [-abehuwxACHPSWY] [-c vcpus] [-g <gdb port>] [-l <lpc>]\n"
 		"       %*s [-m mem] [-p vcpu:hostcpu] [-s <pci>] [-U uuid] \n"
 		"       %*s [--vsbl vsbl_file_name] [--part_info part_info_name]\n"
-		"	%*s <vm>\n"
+		"	%*s [--enable_trusty] <vm>\n"
 		"       -a: local apic is in xAPIC mode (deprecated)\n"
 		"       -A: create ACPI tables\n"
 		"       -c: # cpus (default 1)\n"
@@ -156,7 +157,8 @@ usage(int code)
 		"       -B: bootargs for kernel\n"
 		"       -v: version\n"
 		"       --vsbl: vsbl file path\n"
-		"       --part_info: guest partition info file path\n",
+		"       --part_info: guest partition info file path\n"
+		"	--enable_trusty: enable trusty for guest\n",
 		progname, (int)strlen(progname), "", (int)strlen(progname), "",
 		(int)strlen(progname), "");
 
@@ -555,6 +557,7 @@ sig_handler_term(int signo)
 enum {
 	CMD_OPT_VSBL = 1000,
 	CMD_OPT_PART_INFO,
+	CMD_OPT_TRUSTY_ENABLE,
 };
 
 static struct option long_options[] = {
@@ -589,6 +592,8 @@ static struct option long_options[] = {
 	/* Following cmd option only has long option */
 	{"vsbl",		required_argument,	0, CMD_OPT_VSBL},
 	{"part_info",		required_argument,	0, CMD_OPT_PART_INFO},
+	{"enable_trusty",	no_argument,		0,
+					CMD_OPT_TRUSTY_ENABLE},
 	{0,			0,			0,  0  },
 };
 
@@ -736,6 +741,9 @@ main(int argc, char *argv[])
 					optarg);
 				exit(1);
 			}
+			break;
+		case CMD_OPT_TRUSTY_ENABLE:
+			trusty_enabled = 1;
 			break;
 		case 'h':
 			usage(0);

--- a/core/sw_load_vsbl.c
+++ b/core/sw_load_vsbl.c
@@ -282,6 +282,7 @@ acrn_sw_load_vsbl(struct vmctx *ctx)
 	*vsbl_entry = *((uint32_t *) vsbl_start_addr);
 
 	vsbl_para->boot_device_address = boot_blk_bdf;
+	vsbl_para->trusty_enabled = trusty_enabled;
 
 	return 0;
 }

--- a/core/vmmapi.c
+++ b/core/vmmapi.c
@@ -149,6 +149,7 @@ vm_open(const char *name)
 	ctx->lowmem_limit = 2 * GB;
 	ctx->name = (char *)(ctx + 1);
 	strcpy(ctx->name, name);
+	create_vm.secure_world_enabled = trusty_enabled;
 
 	while (retry > 0) {
 		error = ioctl(ctx->fd, IC_CREATE_VM, &create_vm);

--- a/include/dm.h
+++ b/include/dm.h
@@ -38,6 +38,7 @@
 struct vmctx;
 extern int guest_ncpus;
 extern char *guest_uuid_str;
+extern uint8_t trusty_enabled;
 extern char *vsbl_file_name;
 extern char *vmname;
 extern bool stdio_in_use;


### PR DESCRIPTION
The trusty enabled or not will be passed to HV
with create vm hypercall. It's passed to vSBL within
config page also.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>