### PR TITLE
dm: export pci_emul_add_capability

### DIFF
--- a/hw/pci/core.c
+++ b/hw/pci/core.c
@@ -666,7 +666,7 @@ pci_emul_alloc_pbar(struct pci_vdev *pdi, int idx, uint64_t hostbase,
 }
 
 #define	CAP_START_OFFSET	0x40
-static int
+int
 pci_emul_add_capability(struct pci_vdev *dev, u_char *capdata, int caplen)
 {
 	int i, capoff, reallen;

--- a/include/pci_core.h
+++ b/include/pci_core.h
@@ -230,6 +230,8 @@ int	pci_emul_alloc_bar(struct pci_vdev *pdi, int idx,
 int	pci_emul_alloc_pbar(struct pci_vdev *pdi, int idx,
 			    uint64_t hostbase, enum pcibar_type type,
 			    uint64_t size);
+int	pci_emul_add_capability(struct pci_vdev *dev, u_char *capdata,
+				int caplen);
 int	pci_emul_add_msicap(struct pci_vdev *pi, int msgnum);
 int	pci_emul_add_pciecap(struct pci_vdev *pi, int pcie_device_type);
 void	pci_generate_msi(struct pci_vdev *pi, int msgnum);


### PR DESCRIPTION
pci_emul_add_capability is needed by virtio 1.0 framework to add
pci vendor capability from outside of pci core.

Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Reviewed-by: Hao Li <hao.l.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>