### PR TITLE
Virtio 1.0 framework

### DIFF
--- a/hw/pci/virtio/virtio.c
+++ b/hw/pci/virtio/virtio.c
@@ -227,7 +227,40 @@ virtio_vq_init(struct virtio_base *base, uint32_t pfn)
 static void
 virtio_vq_enable(struct virtio_base *base)
 {
-	/* TODO: to be implemented */
+	struct virtio_vq_info *vq;
+	uint16_t qsz;
+	uint64_t phys;
+	size_t size;
+	char *vb;
+
+	vq = &base->queues[base->curq];
+	qsz = vq->qsize;
+
+	/* descriptors */
+	phys = (((uint64_t)vq->gpa_desc[1]) << 32) | vq->gpa_desc[0];
+	size = qsz * sizeof(struct virtio_desc);
+	vb = paddr_guest2host(base->dev->vmctx, phys, size);
+	vq->desc = (struct virtio_desc *)vb;
+
+	/* available ring */
+	phys = (((uint64_t)vq->gpa_avail[1]) << 32) | vq->gpa_avail[0];
+	size = (2 + qsz + 1) * sizeof(uint16_t);
+	vb = paddr_guest2host(base->dev->vmctx, phys, size);
+	vq->avail = (struct vring_avail *)vb;
+
+	/* used ring */
+	phys = (((uint64_t)vq->gpa_used[1]) << 32) | vq->gpa_used[0];
+	size = sizeof(uint16_t) * 3 + sizeof(struct virtio_used) * qsz;
+	vb = paddr_guest2host(base->dev->vmctx, phys, size);
+	vq->used = (struct vring_used *)vb;
+
+	/* Mark queue as allocated, and start at 0 when we use it. */
+	vq->flags = VQ_ALLOC;
+	vq->last_avail = 0;
+	vq->save_used = 0;
+
+	/* Mark queue as enabled. */
+	vq->enabled = true;
 }
 
 /*

--- a/hw/pci/virtio/virtio.c
+++ b/hw/pci/virtio/virtio.c
@@ -1260,8 +1260,15 @@ bad_qindex:
 static uint32_t
 virtio_isr_cfg_read(struct pci_vdev *dev, uint64_t offset, int size)
 {
-	/* TODO: to be implemented */
-	return 0;
+	struct virtio_base *base = dev->arg;
+	uint32_t value = 0;
+
+	value = base->isr;
+	base->isr = 0;		/* a read clears this flag */
+	if (value)
+		pci_lintr_deassert(dev);
+
+	return value;
 }
 
 static uint32_t

--- a/hw/pci/virtio/virtio.c
+++ b/hw/pci/virtio/virtio.c
@@ -96,6 +96,13 @@ virtio_reset_dev(struct virtio_base *base)
 		vq->save_used = 0;
 		vq->pfn = 0;
 		vq->msix_idx = VIRTIO_MSI_NO_VECTOR;
+		vq->gpa_desc[0] = 0;
+		vq->gpa_desc[1] = 0;
+		vq->gpa_avail[0] = 0;
+		vq->gpa_avail[1] = 0;
+		vq->gpa_used[0] = 0;
+		vq->gpa_used[1] = 0;
+		vq->enabled = 0;
 	}
 	base->negotiated_caps = 0;
 	base->curq = 0;
@@ -104,6 +111,9 @@ virtio_reset_dev(struct virtio_base *base)
 		pci_lintr_deassert(base->dev);
 	base->isr = 0;
 	base->msix_cfg_idx = VIRTIO_MSI_NO_VECTOR;
+	base->device_feature_select = 0;
+	base->driver_feature_select = 0;
+	base->config_generation = 0;
 }
 
 /*

--- a/hw/pci/virtio/virtio.c
+++ b/hw/pci/virtio/virtio.c
@@ -1008,6 +1008,19 @@ virtio_set_modern_bar(struct virtio_base *base, bool use_notify_pio)
 	return rc;
 }
 
+void
+virtio_dev_error(struct virtio_base *base)
+{
+	if (base->negotiated_caps & VIRTIO_F_VERSION_1) {
+		/* see 2.1.2. if DRIVER_OK is set, need to send
+		 * a device configuration change notification to the driver
+		 */
+		base->status |= VIRTIO_CR_STATUS_NEEDS_RESET;
+		if (base->status & VIRTIO_CR_STATUS_DRIVER_OK)
+			virtio_config_changed(base);
+	}
+}
+
 static struct cap_region {
 	uint64_t	cap_offset;	/* offset of capability region */
 	int		cap_size;	/* size of capability region */

--- a/hw/pci/virtio/virtio.c
+++ b/hw/pci/virtio/virtio.c
@@ -1340,7 +1340,31 @@ static void
 virtio_notify_cfg_write(struct pci_vdev *dev, uint64_t offset, int size,
 			uint64_t value)
 {
-	/* TODO: to be implemented */
+	struct virtio_base *base = dev->arg;
+	struct virtio_vq_info *vq;
+	struct virtio_ops *vops;
+	const char *name;
+	uint64_t idx;
+
+	idx = offset / VIRTIO_MODERN_NOTIFY_OFF_MULT;
+	vops = base->vops;
+	name = vops->name;
+
+	if (idx >= vops->nvq) {
+		fprintf(stderr,
+			"%s: queue %lu notify out of range\r\n", name, idx);
+		return;
+	}
+
+	vq = &base->queues[idx];
+	if (vq->notify)
+		(*vq->notify)(DEV_STRUCT(base), vq);
+	else if (vops->qnotify)
+		(*vops->qnotify)(DEV_STRUCT(base), vq);
+	else
+		fprintf(stderr,
+			"%s: qnotify queue %lu: missing vq/vops notify\r\n",
+			name, idx);
 }
 
 static uint32_t

--- a/include/virtio.h
+++ b/include/virtio.h
@@ -674,6 +674,10 @@ vq_interrupt(struct virtio_base *vb, struct virtio_vq_info *vq)
 static inline void
 virtio_config_changed(struct virtio_base *vb)
 {
+	if (!(vb->status & VIRTIO_CR_STATUS_DRIVER_OK))
+		return;
+
+	vb->config_generation++;
 
 	if (pci_msix_enabled(vb->dev))
 		pci_generate_msix(vb->dev, vb->msix_cfg_idx);

--- a/include/virtio.h
+++ b/include/virtio.h
@@ -318,7 +318,8 @@ struct vring_used {
 
 /* From section 2.3, "Virtqueue Configuration", of the virtio specification */
 /**
- * @brief Calculate size of a virtual ring.
+ * @brief Calculate size of a virtual ring, this interface is only valid for
+ * legacy virtio.
  *
  * @param qsz Size of raw data in a certain virtqueue.
  *

--- a/include/virtio.h
+++ b/include/virtio.h
@@ -842,6 +842,19 @@ void virtio_pci_write(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 		      int baridx, uint64_t offset, int size, uint64_t value);
 
 /**
+ * @brief Indicate the device has experienced an error.
+ *
+ * This is called when the device has experienced an error from which it
+ * cannot re-cover. DEVICE_NEEDS_RESET is set to the device status register
+ * and a config change intr is sent to the guest driver.
+ *
+ * @param base Pointer to struct virtio_base.
+ *
+ * @return N/A
+ */
+void virtio_dev_error(struct virtio_base *base);
+
+/**
  * @brief Set modern BAR (usually 4) to map PCI config registers.
  *
  * Set modern MMIO BAR (usually 4) to map virtio 1.0 capabilities and optional

--- a/include/virtio.h
+++ b/include/virtio.h
@@ -284,6 +284,12 @@ struct vring_used {
 				/* guest OS driver is loaded */
 #define	VIRTIO_CR_STATUS_DRIVER_OK	0x04
 				/* guest OS driver ready */
+#define	VIRTIO_CR_STATUS_FEATURES_OK	0x08
+				/* features negotiation complete */
+#define	VIRTIO_CR_STATUS_NEEDS_RESET	0x40
+				/* device experienced an error and cannot
+				 * recover, guest driver must reset it
+				 */
 #define	VIRTIO_CR_STATUS_FAILED		0x80
 				/* guest has given up on this dev */
 
@@ -306,6 +312,9 @@ struct vring_used {
 #define	VIRTIO_F_NOTIFY_ON_EMPTY	(1 << 24)
 #define	VIRTIO_RING_F_INDIRECT_DESC	(1 << 28)
 #define	VIRTIO_RING_F_EVENT_IDX		(1 << 29)
+
+/* v1.0 compliant. */
+#define VIRTIO_F_VERSION_1		(1UL << 32)
 
 /* From section 2.3, "Virtqueue Configuration", of the virtio specification */
 /**
@@ -368,6 +377,87 @@ struct virtio_vq_info;
 #define	VIRTIO_USE_MSIX		0x01
 #define	VIRTIO_EVENT_IDX	0x02	/* use the event-index values */
 #define	VIRTIO_BROKED		0x08	/* ??? */
+
+/* Common configuration */
+#define VIRTIO_PCI_CAP_COMMON_CFG	1
+/* Notifications */
+#define VIRTIO_PCI_CAP_NOTIFY_CFG	2
+/* ISR access */
+#define VIRTIO_PCI_CAP_ISR_CFG		3
+/* Device specific configuration */
+#define VIRTIO_PCI_CAP_DEVICE_CFG	4
+/* PCI configuration access */
+#define VIRTIO_PCI_CAP_PCI_CFG		5
+
+#define VIRTIO_COMMON_DFSELECT		0
+#define VIRTIO_COMMON_DF		4
+#define VIRTIO_COMMON_GFSELECT		8
+#define VIRTIO_COMMON_GF		12
+#define VIRTIO_COMMON_MSIX		16
+#define VIRTIO_COMMON_NUMQ		18
+#define VIRTIO_COMMON_STATUS		20
+#define VIRTIO_COMMON_CFGGENERATION	21
+#define VIRTIO_COMMON_Q_SELECT		22
+#define VIRTIO_COMMON_Q_SIZE		24
+#define VIRTIO_COMMON_Q_MSIX		26
+#define VIRTIO_COMMON_Q_ENABLE		28
+#define VIRTIO_COMMON_Q_NOFF		30
+#define VIRTIO_COMMON_Q_DESCLO		32
+#define VIRTIO_COMMON_Q_DESCHI		36
+#define VIRTIO_COMMON_Q_AVAILLO		40
+#define VIRTIO_COMMON_Q_AVAILHI		44
+#define VIRTIO_COMMON_Q_USEDLO		48
+#define VIRTIO_COMMON_Q_USEDHI		52
+
+/* Fields in VIRTIO_PCI_CAP_COMMON_CFG: */
+struct virtio_pci_common_cfg {
+	/* About the whole device. */
+	uint32_t device_feature_select;	/* read-write */
+	uint32_t device_feature;	/* read-only */
+	uint32_t guest_feature_select;	/* read-write */
+	uint32_t guest_feature;		/* read-write */
+	uint16_t msix_config;		/* read-write */
+	uint16_t num_queues;		/* read-only */
+	uint8_t device_status;		/* read-write */
+	uint8_t config_generation;	/* read-only */
+
+	/* About a specific virtqueue. */
+	uint16_t queue_select;		/* read-write */
+	uint16_t queue_size;		/* read-write, power of 2. */
+	uint16_t queue_msix_vector;	/* read-write */
+	uint16_t queue_enable;		/* read-write */
+	uint16_t queue_notify_off;	/* read-only */
+	uint32_t queue_desc_lo;		/* read-write */
+	uint32_t queue_desc_hi;		/* read-write */
+	uint32_t queue_avail_lo;	/* read-write */
+	uint32_t queue_avail_hi;	/* read-write */
+	uint32_t queue_used_lo;		/* read-write */
+	uint32_t queue_used_hi;		/* read-write */
+};
+
+/* PCI capability header: */
+struct virtio_pci_cap {
+	uint8_t cap_vndr;	/* Generic PCI field: PCI_CAP_ID_VNDR */
+	uint8_t cap_next;	/* Generic PCI field: next ptr. */
+	uint8_t cap_len;	/* Generic PCI field: capability length */
+	uint8_t cfg_type;	/* Identifies the structure. */
+	uint8_t bar;		/* Where to find it. */
+	uint8_t padding[3];	/* Pad to full dword. */
+	uint32_t offset;	/* Offset within bar. */
+	uint32_t length;	/* Length of the structure, in bytes. */
+};
+
+/* Fields in VIRTIO_PCI_CAP_NOTIFY_CFG: */
+struct virtio_pci_notify_cap {
+	struct virtio_pci_cap cap;
+	uint32_t notify_off_multiplier;	/* Multiplier for queue_notify_off. */
+};
+
+/* Fields in VIRTIO_PCI_CAP_PCI_CFG: */
+struct virtio_pci_cfg_cap {
+	struct virtio_pci_cap cap;
+	uint8_t pci_cfg_data[4]; /* Data for BAR access. */
+};
 
 /**
  * @brief Base component to any virtio device

--- a/include/virtio.h
+++ b/include/virtio.h
@@ -839,6 +839,21 @@ uint64_t virtio_pci_read(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
  */
 void virtio_pci_write(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 		      int baridx, uint64_t offset, int size, uint64_t value);
+
+/**
+ * @brief Set modern BAR (usually 4) to map PCI config registers.
+ *
+ * Set modern MMIO BAR (usually 4) to map virtio 1.0 capabilities and optional
+ * set modern PIO BAR (usually 2) to map notify capability. This interface is
+ * only valid for modern virtio.
+ *
+ * @param base Pointer to struct virtio_base.
+ * @param use_notify_pio Whether use pio for notify capability.
+ *
+ * @return 0 on success and non-zero on fail.
+ */
+int virtio_set_modern_bar(struct virtio_base *base, bool use_notify_pio);
+
 /**
  * @}
  */


### PR DESCRIPTION
This patchset implemented the virtio 1.0 framework based on virtio spec
v1.0 cs4.

Currently only modern feature negotiation has been verified to be working
with virtio 1.0 support. New VBS-U, e.g. virtio-input, based on virtio 1.0
specification will be developed to verify the correctness of virtio 1.0
framework.

Two PCI bars are used in virtio 0.9.5 (referred as virtio legacy). One is
for PIO, the other is for MSIX. Both the virtio common configuration
registers and device-specific configuration registers are placed in the
PIO bar together.

In virtio 1.0 (referred as virtio modern) 5 PCI capabilities are added to
the PCI configuration space of the virtio PCI device.
- Common configuration capability
- Notification capability
- ISR capability
- Device-specific configuration capability
- PCI configuration access capability.

Each capability except the last one has a corresponding bar region which
is used for its registers. In our implementation a 64-bit MMIO bar is
allocated to accommodate all the 4 regions.

Optionally a PIO notify capability is added to the PCI configuration space
and a PIO bar is allocated for it accordingly.

Virtio PCI device bar layout:
0   - legacy PIO bar
1   - MSIX bar
2   - modern PIO bar, used as notify
4+5 - modern 64-bit MMIO bar

PCI bar layout for legacy/modern/transitional devices:
legacy                         - (0) + (1)
modern (no pio notify)         - (1) + (4+5)
modern (with pio notify)       - (1) + (2) + (4+5)
transitional (no pio notify)   - (0) + (1) + (4+5)
transitional (with pio notify) - (0) + (1) + (2) + (4+5)