### PR TITLE
Enable Travis CI testing

### DIFF
--- a/.travis-dockerfiles/Dockerfile.centos7
+++ b/.travis-dockerfiles/Dockerfile.centos7
@@ -1,0 +1,16 @@
+# Build container based on CentOS 7
+FROM centos:centos7
+
+RUN yum -y update; yum clean all
+RUN yum -y install gcc \
+                   git \
+                   make \
+                   vim \
+                   libuuid-devel \
+                   openssl-devel \
+                   libpciaccess-devel \
+                   gnu-efi-devel
+
+WORKDIR /root/acrn
+
+CMD ["/bin/bash"]

--- a/.travis-dockerfiles/Dockerfile.clearlinux
+++ b/.travis-dockerfiles/Dockerfile.clearlinux
@@ -1,0 +1,10 @@
+# Build container based on Clearlinux
+FROM clearlinux:base
+
+# python-basic-dev is only there because it gives us
+# the openssl/md5.h header that we need
+RUN swupd bundle-add os-core-dev dev-utils-dev
+
+WORKDIR /root/acrn
+
+CMD ["/bin/bash"]

--- a/.travis-dockerfiles/Dockerfile.debian8
+++ b/.travis-dockerfiles/Dockerfile.debian8
@@ -1,0 +1,15 @@
+# Build container based on Debian 8
+FROM debian:8
+
+# Install dependencies.
+RUN apt-get update \
+    && apt-get install -y gcc make vim git \
+                          gnu-efi \
+                          libssl-dev \
+                          libpciaccess-dev \
+                          uuid-dev \
+    && apt-get clean
+
+WORKDIR /root/acrn
+
+CMD ["/bin/bash"]

--- a/.travis-dockerfiles/Dockerfile.fedora26
+++ b/.travis-dockerfiles/Dockerfile.fedora26
@@ -1,0 +1,16 @@
+# Build container based on Fedora 26
+FROM fedora:26
+
+RUN dnf -y update && dnf clean all
+RUN dnf -y install gcc \
+                   git \
+                   make \
+                   vim \
+                   libuuid-devel \
+                   openssl-devel \
+                   libpciaccess-devel \
+                   gnu-efi-devel
+
+WORKDIR /root/acrn
+
+CMD ["/bin/bash"]

--- a/.travis-dockerfiles/Dockerfile.fedora27
+++ b/.travis-dockerfiles/Dockerfile.fedora27
@@ -1,0 +1,16 @@
+# Build container based on Fedora 27
+FROM fedora:27
+
+RUN dnf -y update && dnf clean all
+RUN dnf -y install gcc \
+                   git \
+                   make \
+                   vim \
+                   libuuid-devel \
+                   openssl-devel \
+                   libpciaccess-devel \
+                   gnu-efi-devel
+
+WORKDIR /root/acrn
+
+CMD ["/bin/bash"]

--- a/.travis-dockerfiles/Dockerfile.ubuntu14.04
+++ b/.travis-dockerfiles/Dockerfile.ubuntu14.04
@@ -1,0 +1,15 @@
+# Build container based on Ubuntu 14.04
+FROM ubuntu:14.04
+
+# Install dependencies.
+RUN apt-get update \
+    && apt-get install -y gcc make vim git \
+                          gnu-efi \
+                          libssl-dev \
+                          libpciaccess-dev \
+                          uuid-dev \
+    && apt-get clean
+
+WORKDIR /root/acrn
+
+CMD ["/bin/bash"]

--- a/.travis-dockerfiles/Dockerfile.ubuntu16.04
+++ b/.travis-dockerfiles/Dockerfile.ubuntu16.04
@@ -1,0 +1,15 @@
+# Build container based on Ubuntu 16.04
+FROM ubuntu:16.04
+
+# Install dependencies.
+RUN apt-get update \
+    && apt-get install -y gcc make vim git \
+                          gnu-efi \
+                          libssl-dev \
+                          libpciaccess-dev \
+                          uuid-dev \
+    && apt-get clean
+
+WORKDIR /root/acrn
+
+CMD ["/bin/bash"]

--- a/.travis-dockerfiles/README.md
+++ b/.travis-dockerfiles/README.md
@@ -1,0 +1,80 @@
+# Build containers for Project ACRN
+
+## Introduction
+
+This folder contains a number of Dockerfile that include
+all the build tools and dependencies to build the ACRN Project
+components, i.e. the `acrn-hypervisor` and `acrn-devicemodel`
+
+The workflow is pretty simple and can be summarized in these few steps:
+
+1. Build the *build containers* based on your preferred OS
+1. Clone the Project ACRN repositories
+1. Start the build container and give it the repositories
+1. Build the Project ACRN components
+
+The pre-requisite is that you have Docker installed on your machine.
+Explaining how to install it on your system is beyond the scope of this
+document, please visit https://www.docker.com for detailed instructions.
+
+## Build the *build containers*
+
+Each `Dockerfile` in this repo has an extension that tells what Linux
+distribution it is based on. To build a container using any of those,
+use this command:
+```
+$ sudo docker build -t <container-name> -f Dockerfile.<baseos> .
+```
+
+As an example, to build a container based on CentOS 7, do:
+```
+$ sudo docker build -t centos7 -f Dockerfile.centos7 .
+```
+
+## Clone Project ACRN
+
+Follow these simple steps to clone the Project ACRN repositories
+```
+$ mkdir ~/acrn
+$ cd ~/acrn
+$ git clone https://github.com/projectacrn/acrn-hypervisor
+$ git clone https://github.com/projectacrn/acrn-devicemodel
+```
+
+## Start the build container
+
+Use this `~/acrn` folder and pass it on to your build container:
+```
+$ cd ~/acrn
+$ sudo docker run -ti -v $PWD:/root/acrn <container-name>
+```
+
+Using CentOS 7 again as an example, that gives us:
+```
+$ cd ~/acrn
+$ sudo docker run -ti -v $PWD:/root/acrn centos7
+```
+
+**Note:** if you encounter permission issues within the container (as it
+happens on a Fedora 27 host), try adding the `:z` parameter to the mount option.
+This will unlock the permission restriction (that comes from SElinux). Your
+command-line would then be:
+```
+$ cd ~/acrn
+$ sudo docker run -ti -v $PWD:/root/acrn:z centos7
+```
+
+## Build the ACRN components
+
+The steps above place you inside the container and give you access to
+the Project ACRN repositories you cloned earlier. You can now build any
+of the components. Here is an example:
+```
+# cd acrn-hypervisor
+# make PLATFORM=uefi RELEASE=1
+```
+
+You can do this for all build combinations and also try to build the `acrn-devicemodel`.
+All the build dependencies and tools are pre-installed in the container as well as a
+couple of useful tools (`git` and `vim`) so you can directly edit files to experiment
+from within the container.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+
+language: c
+
+env:
+   global:
+      - OS_TESTED_CL="clearlinux"
+      - OS_TESTED_UBUNTU="ubuntu16.04"
+      - OS_TESTED_FEDORA="fedora26"
+
+services:
+   - docker
+
+before_install:
+   - docker build -t ${OS_TESTED_CL} -f .travis-dockerfiles/Dockerfile.${OS_TESTED_CL} .
+   - docker build -t ${OS_TESTED_UBUNTU} -f .travis-dockerfiles/Dockerfile.${OS_TESTED_UBUNTU} .
+   - docker build -t ${OS_TESTED_FEDORA} -f .travis-dockerfiles/Dockerfile.${OS_TESTED_FEDORA} .
+   - docker images
+
+install: true
+
+script:
+   - docker run -v $PWD:/root/acrn ${OS_TESTED_CL} /bin/bash -c "make clean && make"
+   - docker run -v $PWD:/root/acrn ${OS_TESTED_UBUNTU} /bin/bash -c "make clean && make"
+   - docker run -v $PWD:/root/acrn ${OS_TESTED_FEDORA} /bin/bash -c "make clean && make"


### PR DESCRIPTION
Enable Travis CI testing for the following development host OSs:
* Clearlinux
* Ubuntu 16.04
* Fedora 26

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>