### PR TITLE
DM: Build UOS ACPI DSDT with Px data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ SRCS += hw/pci/virtio/virtio_hyper_dmabuf.c
 SRCS += hw/pci/irq.c
 SRCS += hw/pci/uart.c
 SRCS += hw/acpi/acpi.c
+SRCS += hw/acpi/acpi_pm.c
 
 # core
 #SRCS += core/bootrom.c

--- a/core/vmmapi.c
+++ b/core/vmmapi.c
@@ -720,3 +720,9 @@ vm_get_device_fd(struct vmctx *ctx)
 {
 	return ctx->fd;
 }
+
+int
+vm_get_cpu_state(struct vmctx *ctx, void *state_buf)
+{
+	return ioctl(ctx->fd, IC_PM_GET_CPU_STATE, state_buf);
+}

--- a/hw/acpi/acpi.c
+++ b/hw/acpi/acpi.c
@@ -764,6 +764,9 @@ basl_fwrite_dsdt(FILE *fp, struct vmctx *ctx)
 	dsdt_line("      })");
 	dsdt_line("    }");
 	dsdt_line("  }");
+
+	pm_write_dsdt(ctx, basl_ncpu);
+
 	dsdt_line("}");
 
 	if (dsdt_error != 0)

--- a/hw/acpi/acpi.c
+++ b/hw/acpi/acpi.c
@@ -118,7 +118,7 @@ struct basl_fio {
 #define EFFLUSH(x) fflush(x)
 
 static int
-basl_fwrite_rsdp(FILE *fp)
+basl_fwrite_rsdp(FILE *fp, struct vmctx *ctx)
 {
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * dm RSDP template\n");
@@ -141,7 +141,7 @@ basl_fwrite_rsdp(FILE *fp)
 }
 
 static int
-basl_fwrite_rsdt(FILE *fp)
+basl_fwrite_rsdt(FILE *fp, struct vmctx *ctx)
 {
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * dm RSDT template\n");
@@ -174,7 +174,7 @@ basl_fwrite_rsdt(FILE *fp)
 }
 
 static int
-basl_fwrite_xsdt(FILE *fp)
+basl_fwrite_xsdt(FILE *fp, struct vmctx *ctx)
 {
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * dm XSDT template\n");
@@ -207,7 +207,7 @@ basl_fwrite_xsdt(FILE *fp)
 }
 
 static int
-basl_fwrite_madt(FILE *fp)
+basl_fwrite_madt(FILE *fp, struct vmctx *ctx)
 {
 	int i;
 
@@ -291,7 +291,7 @@ basl_fwrite_madt(FILE *fp)
 }
 
 static int
-basl_fwrite_fadt(FILE *fp)
+basl_fwrite_fadt(FILE *fp, struct vmctx *ctx)
 {
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * dm FADT template\n");
@@ -505,7 +505,7 @@ basl_fwrite_fadt(FILE *fp)
 }
 
 static int
-basl_fwrite_hpet(FILE *fp)
+basl_fwrite_hpet(FILE *fp, struct vmctx *ctx)
 {
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * dm HPET template\n");
@@ -547,7 +547,7 @@ basl_fwrite_hpet(FILE *fp)
 }
 
 static int
-basl_fwrite_mcfg(FILE *fp)
+basl_fwrite_mcfg(FILE *fp, struct vmctx *ctx)
 {
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * dm MCFG template\n");
@@ -577,7 +577,7 @@ basl_fwrite_mcfg(FILE *fp)
 }
 
 static int
-basl_fwrite_nhlt(FILE *fp)
+basl_fwrite_nhlt(FILE *fp, struct vmctx *ctx)
 {
 	int offset, len;
 	uint8_t data;
@@ -634,7 +634,7 @@ basl_fwrite_nhlt(FILE *fp)
 }
 
 static int
-basl_fwrite_facs(FILE *fp)
+basl_fwrite_facs(FILE *fp, struct vmctx *ctx)
 {
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * dm FACS template\n");
@@ -729,7 +729,7 @@ dsdt_fixed_mem32(uint32_t base, uint32_t length)
 }
 
 static int
-basl_fwrite_dsdt(FILE *fp)
+basl_fwrite_dsdt(FILE *fp, struct vmctx *ctx)
 {
 	dsdt_fp = fp;
 	dsdt_error = 0;
@@ -852,7 +852,9 @@ basl_load(struct vmctx *ctx, int fd, uint64_t off)
 }
 
 static int
-basl_compile(struct vmctx *ctx, int (*fwrite_section)(FILE *), uint64_t offset)
+basl_compile(struct vmctx *ctx,
+		int (*fwrite_section)(FILE *, struct vmctx *),
+		uint64_t offset)
 {
 	struct basl_fio io[2];
 	static char iaslbuf[3*MAXPATHLEN + 10];
@@ -860,7 +862,7 @@ basl_compile(struct vmctx *ctx, int (*fwrite_section)(FILE *), uint64_t offset)
 
 	err = basl_start(&io[0], &io[1]);
 	if (!err) {
-		err = (*fwrite_section)(io[0].fp);
+		err = (*fwrite_section)(io[0].fp, ctx);
 
 		if (!err) {
 			/*
@@ -947,7 +949,7 @@ basl_make_templates(void)
 }
 
 static struct {
-	int	(*wsect)(FILE *fp);
+	int	(*wsect)(FILE *fp, struct vmctx *ctx);
 	uint64_t  offset;
 	bool	valid;
 } basl_ftables[] = {

--- a/hw/acpi/acpi_pm.c
+++ b/hw/acpi/acpi_pm.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "vmm.h"
+#include "vmmapi.h"
+#include "dm.h"
+#include "acpi.h"
+
+uint8_t get_vcpu_px_cnt(struct vmctx *ctx, int vcpu_id)
+{
+	uint64_t pm_ioctl_buf = 0;
+	enum pm_cmd_type cmd_type = PMCMD_GET_PX_CNT;
+
+	pm_ioctl_buf = ((ctx->vmid << PMCMD_VMID_SHIFT) & PMCMD_VMID_MASK)
+			| ((vcpu_id << PMCMD_VCPUID_SHIFT) & PMCMD_VCPUID_MASK)
+			| cmd_type;
+
+	if (vm_get_cpu_state(ctx, &pm_ioctl_buf)) {
+		return 0;
+	}
+
+	return (uint8_t)pm_ioctl_buf;
+}
+
+int get_vcpu_px_data(struct vmctx *ctx, int vcpu_id,
+			int px_num, struct cpu_px_data *vcpu_px_data)
+{
+	uint64_t *pm_ioctl_buf;
+	enum pm_cmd_type cmd_type = PMCMD_GET_PX_DATA;
+
+	pm_ioctl_buf = malloc(sizeof(struct cpu_px_data));
+	if (!pm_ioctl_buf) {
+		return -1;
+	}
+
+	*pm_ioctl_buf = ((ctx->vmid << PMCMD_VMID_SHIFT) & PMCMD_VMID_MASK)
+		| ((vcpu_id << PMCMD_VCPUID_SHIFT) & PMCMD_VCPUID_MASK)
+		| ((px_num << PMCMD_STATE_NUM_SHIFT) & PMCMD_STATE_NUM_MASK)
+		| cmd_type;
+
+	/* get and validate px data */
+	if (vm_get_cpu_state(ctx, pm_ioctl_buf)) {
+		free(pm_ioctl_buf);
+		return -1;
+	}
+
+	memcpy(vcpu_px_data, pm_ioctl_buf,
+			sizeof(struct cpu_px_data));
+
+	free(pm_ioctl_buf);
+	return 0;
+}

--- a/include/acpi.h
+++ b/include/acpi.h
@@ -57,5 +57,6 @@ void	dsdt_fixed_mem32(uint32_t base, uint32_t length);
 void	dsdt_indent(int levels);
 void	dsdt_unindent(int levels);
 void	sci_init(struct vmctx *ctx);
+void	pm_write_dsdt(struct vmctx *ctx, int ncpu);
 
 #endif /* _ACPI_H_ */

--- a/include/public/acrn_common.h
+++ b/include/public/acrn_common.h
@@ -303,6 +303,39 @@ struct acrn_vm_pci_msix_remap {
 #define GUEST_CFG_OFFSET	0xd0000
 
 /**
+ * @brief Info The power state data of a VCPU.
+ *
+ */
+struct cpu_px_data {
+	uint64_t core_frequency;	/* megahertz */
+	uint64_t power;			/* milliWatts */
+	uint64_t transition_latency;	/* microseconds */
+	uint64_t bus_master_latency;	/* microseconds */
+	uint64_t control;		/* control value */
+	uint64_t status;		/* success indicator */
+} __attribute__((aligned(8)));
+
+/**
+ * @brief Info PM command from DM/VHM.
+ *
+ * The command would specify request type(i.e. get px count or data) for
+ * specific VM and specific VCPU with specific state number.like P(n).
+ */
+#define PMCMD_VMID_MASK		0xff000000
+#define PMCMD_VCPUID_MASK	0x00ff0000
+#define PMCMD_STATE_NUM_MASK	0x0000ff00
+#define PMCMD_TYPE_MASK		0x000000ff
+
+#define PMCMD_VMID_SHIFT	24
+#define PMCMD_VCPUID_SHIFT	16
+#define PMCMD_STATE_NUM_SHIFT	8
+
+enum pm_cmd_type {
+	PMCMD_GET_PX_CNT,
+	PMCMD_GET_PX_DATA,
+};
+
+/**
  * @}
  */
 #endif /* _ACRN_COMMON_H_ */

--- a/include/public/vhm_ioctl_defs.h
+++ b/include/public/vhm_ioctl_defs.h
@@ -101,6 +101,10 @@
 #define IC_SET_PTDEV_INTR_INFO         _IC_ID(IC_ID, IC_ID_PCI_BASE + 0x03)
 #define IC_RESET_PTDEV_INTR_INFO       _IC_ID(IC_ID, IC_ID_PCI_BASE + 0x04)
 
+/* Power management */
+#define IC_ID_PM_BASE                   0x60UL
+#define IC_PM_GET_CPU_STATE            _IC_ID(IC_ID, IC_ID_PM_BASE + 0x00)
+
 /**
  * struct vm_memseg - memory segment info for guest
  *

--- a/include/vmmapi.h
+++ b/include/vmmapi.h
@@ -141,4 +141,7 @@ int	vm_set_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf,
 int	vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin);
 
 int	vm_create_vcpu(struct vmctx *ctx, int vcpu_id);
+
+int	vm_get_cpu_state(struct vmctx *ctx, void *state_buf);
+
 #endif	/* _VMMAPI_H_ */


### PR DESCRIPTION
The patch set would generate ACPI P-state objects(i.e. _PCT/_PPC/_PSS) ASL
for DSDT, to make UOS be capable of controling its P-state.

HV is responsible for constructing Px data and provide hypercall for VHM
to query, then DM will get these data through kernel VHM service and build
the DSDT for UOS.

With this patch set, UOS CPU should have P-state working if acpi-cpufreq
driver is enabled in UOS kernel.


change log:

	v4: (1) px data should be per-cpu of target vm, but v3 did not
		specify the target vm and vcpu so just get the vcpu px data
		of vm0, fixed it to specific vm and vcpu;
	    (2) add vmctx as parameter of write acpi table function pointer,
		so we can pass vmid to write dsdt function;
	    (3) do not need store px data before build acpi table, just
		get the px data when building dsdt table;
	    (4) build the _PSS for each vcpu;

	v3: (1) move some acpi_pm struct defintion to acrn_common.h;
	    (2) change name of acrn_px_data to cpu_px_data;
	    (3) fix memory leak of pm_ioctl_buf;

	v2: (1) DM ioctl only query one specific cpu pstate data instead of
		all cpu state data;

	v1: Initial version;