### PR TITLE
Fix compilation on Ubuntu 14.04

### DIFF
--- a/hw/pci/ahci.c
+++ b/hw/pci/ahci.c
@@ -1478,7 +1478,7 @@ static void
 atapi_mode_sense(struct ahci_port *p, int slot, uint8_t *cfis)
 {
 	uint8_t *acmd;
-	uint32_t tfd;
+	uint32_t tfd =0;
 	uint8_t pc, code;
 	int len;
 

--- a/include/pci_core.h
+++ b/include/pci_core.h
@@ -270,14 +270,14 @@ static inline void
 pci_set_cfgdata16(struct pci_vdev *pi, int offset, uint16_t val)
 {
 	assert(offset <= (PCI_REGMAX - 1) && (offset & 1) == 0);
-	*(uint16_t *)(pi->cfgdata + offset) = val;
+	*(uint16_t *)((uint16_t *)pi->cfgdata + offset) = val;
 }
 
 static inline void
 pci_set_cfgdata32(struct pci_vdev *pi, int offset, uint32_t val)
 {
 	assert(offset <= (PCI_REGMAX - 3) && (offset & 3) == 0);
-	*(uint32_t *)(pi->cfgdata + offset) = val;
+	*(uint32_t *)((uint32_t *)pi->cfgdata + offset) = val;
 }
 
 static inline uint8_t
@@ -291,14 +291,14 @@ static inline uint16_t
 pci_get_cfgdata16(struct pci_vdev *pi, int offset)
 {
 	assert(offset <= (PCI_REGMAX - 1) && (offset & 1) == 0);
-	return (*(uint16_t *)(pi->cfgdata + offset));
+	return (*(uint16_t *)((uint16_t *)pi->cfgdata + offset));
 }
 
 static inline uint32_t
 pci_get_cfgdata32(struct pci_vdev *pi, int offset)
 {
 	assert(offset <= (PCI_REGMAX - 3) && (offset & 3) == 0);
-	return (*(uint32_t *)(pi->cfgdata + offset));
+	return (*(uint32_t *)((uint32_t *)pi->cfgdata + offset));
 }
 
 #endif /* _PCI_CORE_H_ */


### PR DESCRIPTION
A couple of problems appeared on Ubuntu 14.04 (gcc 4.8.4) when we
turned on additional compiler flags with commit
519c4285cf104a594776591075ee1c6ee4d61815a. This patch fixes these
problems by adhering to the strict anti-aliasing rules and also
initializing the 'tfd' variable where the compile believed it
_could_ be used uninitialized.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>