### PR TITLE
Revert "Fix compilation on Ubuntu 14.04"

### DIFF
--- a/hw/pci/ahci.c
+++ b/hw/pci/ahci.c
@@ -1478,7 +1478,7 @@ static void
 atapi_mode_sense(struct ahci_port *p, int slot, uint8_t *cfis)
 {
 	uint8_t *acmd;
-	uint32_t tfd =0;
+	uint32_t tfd;
 	uint8_t pc, code;
 	int len;
 

--- a/include/pci_core.h
+++ b/include/pci_core.h
@@ -270,14 +270,14 @@ static inline void
 pci_set_cfgdata16(struct pci_vdev *pi, int offset, uint16_t val)
 {
 	assert(offset <= (PCI_REGMAX - 1) && (offset & 1) == 0);
-	*(uint16_t *)((uint16_t *)pi->cfgdata + offset) = val;
+	*(uint16_t *)(pi->cfgdata + offset) = val;
 }
 
 static inline void
 pci_set_cfgdata32(struct pci_vdev *pi, int offset, uint32_t val)
 {
 	assert(offset <= (PCI_REGMAX - 3) && (offset & 3) == 0);
-	*(uint32_t *)((uint32_t *)pi->cfgdata + offset) = val;
+	*(uint32_t *)(pi->cfgdata + offset) = val;
 }
 
 static inline uint8_t
@@ -291,14 +291,14 @@ static inline uint16_t
 pci_get_cfgdata16(struct pci_vdev *pi, int offset)
 {
 	assert(offset <= (PCI_REGMAX - 1) && (offset & 1) == 0);
-	return (*(uint16_t *)((uint16_t *)pi->cfgdata + offset));
+	return (*(uint16_t *)(pi->cfgdata + offset));
 }
 
 static inline uint32_t
 pci_get_cfgdata32(struct pci_vdev *pi, int offset)
 {
 	assert(offset <= (PCI_REGMAX - 3) && (offset & 3) == 0);
-	return (*(uint32_t *)((uint32_t *)pi->cfgdata + offset));
+	return (*(uint32_t *)(pi->cfgdata + offset));
 }
 
 #endif /* _PCI_CORE_H_ */


### PR DESCRIPTION
This reverts commit bc0579d0ffba6a1b0d1abe55a0af03d935b959f0.

The commit bc0579d makes acrn-dm crashed when launch UOS.
Crash log:
./launch_UOS.sh: line 112:   377 Segmentation fault (core dumped) acrn-dm ...
dmesg log:
acrn-dm[1264]: segfault at 1f0 ip 0000000000412257 sp 00007fffc1af9920 error 6 in acrn-dm[400000+3d000]

After this patch reverted, UOS launched successfully.