### PR TITLE
DM: fix build issue with gcc 4.8.4 on ubuntu 14.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CFLAGS += -m64
 CFLAGS += -Wall -ffunction-sections
 CFLAGS += -Werror
 CFLAGS += -O2 -D_FORTIFY_SOURCE=2
-CFLAGS += -Wformat -Wformat-security
+CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
 
 CFLAGS += -I$(BASEDIR)/include
 CFLAGS += -I$(BASEDIR)/include/public

--- a/hw/pci/ahci.c
+++ b/hw/pci/ahci.c
@@ -1478,7 +1478,7 @@ static void
 atapi_mode_sense(struct ahci_port *p, int slot, uint8_t *cfis)
 {
 	uint8_t *acmd;
-	uint32_t tfd;
+	uint32_t tfd = 0;
 	uint8_t pc, code;
 	int len;
 


### PR DESCRIPTION
There are two build issues:
- add -fno-strict-aliasing to address
  error: dereferencing type-punned pointer will break strict-aliasing rules

- initialize tfd to zero to address
  error: ‘tfd’ may be used uninitialized in this function

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>