### PR TITLE
dm: virtio-console: Fix the bug that ports cannot work

### DIFF
--- a/hw/pci/virtio/virtio_console.c
+++ b/hw/pci/virtio/virtio_console.c
@@ -883,7 +883,8 @@ virtio_console_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		if (backend[0] == '@') {
 			is_console = true;
 			backend++;
-		}
+		} else
+			is_console = false;
 
 		be_type = virtio_console_get_be_type(backend);
 		if (be_type == VIRTIO_CONSOLE_BE_INVALID) {


### PR DESCRIPTION
If multiple ports are defined in the command line, is_console is
not set to a correct value for non-console ports when the definition
of this non-console port is following the definition of a console port.
For example in below definition, the second port is configured as
console port which is not correct:

-s 5,virtio-console,@pty:pty_port,file:file_port=/home/root/test1

Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>