### PR TITLE
DM: fix virtio_net tx_thread block issue

### DIFF
--- a/hw/pci/virtio/virtio_net.c
+++ b/hw/pci/virtio/virtio_net.c
@@ -714,6 +714,11 @@ virtio_net_tx_thread(void *param)
 	pthread_mutex_lock(&net->tx_mtx);
 	error = pthread_cond_wait(&net->tx_cond, &net->tx_mtx);
 	assert(error == 0);
+	if (net->closing) {
+		WPRINTF(("vtnet tx thread closing...\n"));
+		pthread_mutex_unlock(&net->tx_mtx);
+		return NULL;
+	}
 
 	for (;;) {
 		/* note - tx mutex is locked here */
@@ -729,6 +734,7 @@ virtio_net_tx_thread(void *param)
 			assert(error == 0);
 			if (net->closing) {
 				WPRINTF(("vtnet tx thread closing...\n"));
+				pthread_mutex_unlock(&net->tx_mtx);
 				return NULL;
 			}
 		}


### PR DESCRIPTION
If guest doesn't initialize the net device, the tx thread will
block at the first tx_cond wait. When virtio_net_tx_stop is
invoked, the tx_thread will block on second tx_cond then.

Check whether we should exit tx_thread after first tx_cond
waiting

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Hao Li <hao.l.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>