### PR TITLE
Bugfix: DM:tools:acrnctl launch script output is binary file

### DIFF
--- a/tools/acrn-manager/acrnctl.c
+++ b/tools/acrn-manager/acrnctl.c
@@ -412,7 +412,7 @@ static int acrnctl_do_add(int argc, char *argv[])
 	if (ret < 0)
 		goto get_vmname;
 
-	snprintf(cmd, sizeof(cmd), "grep \"acrnctl: \" ./%s.result", argv[1]);
+	snprintf(cmd, sizeof(cmd), "grep -a \"acrnctl: \" ./%s.result", argv[1]);
 	ret = shell_cmd(cmd, cmd_out, sizeof(cmd_out));
 	if (ret < 0)
 		goto get_vmname;


### PR DESCRIPTION
The launch script can output log messages, that should be text.
But it is not always true. E.g. "launch_UOS.sh -U 2" echo message
contain '\0', The 'grep' command will show "Binary file (xxxxxx)
matches", thus acrnctl can't get the vmname. We can use 'grep -a'
instead.

Acked-by: Xu Anthony <anthony.xu@intel.com>
Reviewed-by: Yan Like <like.yan@intel.com>
Reported-by: Chen ChengX <chengx.chen@intel.com>
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>