### PR TITLE
DM: move boot device option 'b' just after emul

### DIFF
--- a/hw/pci/core.c
+++ b/hw/pci/core.c
@@ -181,10 +181,15 @@ pci_parse_slot(char *opt)
 		if (cp != NULL) {
 			*cp = '\0';
 			config = cp + 1;
-			cp = strchr(config, ',');
-			if (cp != NULL) {
-				*cp = '\0';
-				b = cp + 1;
+			if (*config == 'b') {
+				b = config;
+				cp = config + 1;
+				if (*cp == ',') {
+					*cp = '\0';
+					config = cp + 1;
+				} else {
+					b = NULL;
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
The original code assume there is only one configuration for
virtio-blk, and 'b' is just located after that configuration,
so to get the value of 'b', it will end char *config by adding
'\0' after the first configuration.

Thus, char *config will change from:
  /XXXX_vdisk_file,range=xxx/xxx
to:
  /XXXX_vdisk_file
and char *b will point to:
  range=xxx/xxx
So, the range will never take effect for virtio-blk.

Now, 'b' is designed to located just after emul, and
char *config will point to all configurations after 'b'.

Note: only ",b," is taken for boot device option.

Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Hao Li <hao.l.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>