### PR TITLE
Virtio input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ SRCS += hw/pci/xhci.c
 SRCS += hw/pci/core.c
 SRCS += hw/pci/virtio/virtio_console.c
 SRCS += hw/pci/virtio/virtio_block.c
+SRCS += hw/pci/virtio/virtio_input.c
 SRCS += hw/pci/ahci.c
 SRCS += hw/pci/hostbridge.c
 SRCS += hw/pci/passthrough.c

--- a/hw/pci/virtio/virtio_input.c
+++ b/hw/pci/virtio/virtio_input.c
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/types.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <pthread.h>
+
+#include "dm.h"
+#include "pci_core.h"
+#include "virtio.h"
+#include "mevent.h"
+#include <linux/input.h>
+
+static int virtio_input_debug;
+#define DPRINTF(params) do { if (virtio_input_debug) printf params; } while (0)
+#define WPRINTF(params) (printf params)
+
+/*
+ * Queue definitions.
+ */
+#define VIRTIO_INPUT_EVENT_QUEUE	0
+#define VIRTIO_INPUT_STATUS_QUEUE	1
+#define VIRTIO_INPUT_MAXQ		2
+
+/*
+ * Virtqueue size.
+ */
+#define VIRTIO_INPUT_RINGSZ		64
+
+/*
+ * Default size of the buffer used to hold events between SYN
+ */
+#define VIRTIO_INPUT_PACKET_SIZE	10
+
+/*
+ * Host capabilities
+ */
+#define VIRTIO_INPUT_S_HOSTCAPS		(VIRTIO_F_VERSION_1)
+
+enum virtio_input_config_select {
+	VIRTIO_INPUT_CFG_UNSET		= 0x00,
+	VIRTIO_INPUT_CFG_ID_NAME	= 0x01,
+	VIRTIO_INPUT_CFG_ID_SERIAL	= 0x02,
+	VIRTIO_INPUT_CFG_ID_DEVIDS	= 0x03,
+	VIRTIO_INPUT_CFG_PROP_BITS	= 0x10,
+	VIRTIO_INPUT_CFG_EV_BITS	= 0x11,
+	VIRTIO_INPUT_CFG_ABS_INFO	= 0x12,
+};
+
+struct virtio_input_absinfo {
+	uint32_t min;
+	uint32_t max;
+	uint32_t fuzz;
+	uint32_t flat;
+	uint32_t res;
+};
+
+struct virtio_input_devids {
+	uint16_t bustype;
+	uint16_t vendor;
+	uint16_t product;
+	uint16_t version;
+};
+
+struct virtio_input_event {
+	uint16_t type;
+	uint16_t code;
+	uint32_t value;
+};
+
+/*
+ * Device-specific configuration registers
+ * To query a specific piece of configuration information FE driver sets
+ * "select" and "subsel" accordingly, information size is returned in "size"
+ * and information data is returned in union "u"
+ */
+struct virtio_input_config {
+	uint8_t    select;
+	uint8_t    subsel;
+	uint8_t    size;
+	uint8_t    reserved[5];
+	union {
+		char string[128];
+		uint8_t bitmap[128];
+		struct virtio_input_absinfo abs;
+		struct virtio_input_devids ids;
+	} u;
+};
+
+struct virtio_input_event_elem {
+	struct virtio_input_event		event;
+	struct iovec				iov;
+	uint16_t				idx;
+};
+
+/*
+ * Per-device struct
+ */
+struct virtio_input {
+	struct virtio_base			base;
+	struct virtio_vq_info			queues[VIRTIO_INPUT_MAXQ];
+	pthread_mutex_t				mtx;
+	struct mevent				*mevp;
+	uint64_t				features;
+	struct virtio_input_config		cfg;
+	char					*evdev;
+	char					*serial;
+	int					fd;
+	bool					ready;
+
+	struct virtio_input_event_elem		*event_queue;
+	uint32_t				event_qsize;
+	uint32_t				event_qindex;
+};
+
+static void virtio_input_reset(void *);
+static void virtio_input_neg_features(void *, uint64_t);
+static void virtio_input_set_status(void *, uint64_t);
+static int virtio_input_cfgread(void *, int, int, uint32_t *);
+static int virtio_input_cfgwrite(void *, int, int, uint32_t);
+
+static struct virtio_ops virtio_input_ops = {
+	"virtio_input",			/* our name */
+	VIRTIO_INPUT_MAXQ,		/* we support VTCON_MAXQ virtqueues */
+	sizeof(struct virtio_input_config),	/* config reg size */
+	virtio_input_reset,		/* reset */
+	NULL,				/* device-wide qnotify */
+	virtio_input_cfgread,		/* read virtio config */
+	virtio_input_cfgwrite,		/* write virtio config */
+	virtio_input_neg_features,	/* apply negotiated features */
+	virtio_input_set_status,	/* called on guest set status */
+	VIRTIO_INPUT_S_HOSTCAPS,	/* our capabilities */
+};
+
+static void
+virtio_input_reset(void *vdev)
+{
+	/* to be implemented */
+}
+
+static void
+virtio_input_neg_features(void *vdev, uint64_t negotiated_features)
+{
+	/* to be implemented */
+}
+
+static void
+virtio_input_set_status(void *vdev, uint64_t status)
+{
+	/* to be implemented */
+}
+
+static int
+virtio_input_cfgread(void *vdev, int offset, int size, uint32_t *retval)
+{
+	/* to be implemented */
+	return 0;
+}
+
+static int
+virtio_input_cfgwrite(void *vdev, int offset, int size, uint32_t val)
+{
+	/* to be implemented */
+	return 0;
+}
+
+static int
+virtio_input_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
+{
+	/* to be implemented */
+	DPRINTF(("%s\n", __func__));
+	(void)virtio_input_ops;
+	return 0;
+}
+
+static void
+virtio_input_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
+{
+	/* to be implemented */
+}
+
+struct pci_vdev_ops pci_ops_virtio_input = {
+	.class_name	= "virtio-input",
+	.vdev_init	= virtio_input_init,
+	.vdev_deinit	= virtio_input_deinit,
+	.vdev_barwrite	= virtio_pci_write,
+	.vdev_barread	= virtio_pci_read
+};
+DEFINE_PCI_DEVTYPE(pci_ops_virtio_input);

--- a/hw/pci/virtio/virtio_input.c
+++ b/hw/pci/virtio/virtio_input.c
@@ -157,6 +157,8 @@ static void virtio_input_neg_features(void *, uint64_t);
 static void virtio_input_set_status(void *, uint64_t);
 static int virtio_input_cfgread(void *, int, int, uint32_t *);
 static int virtio_input_cfgwrite(void *, int, int, uint32_t);
+static bool virtio_input_get_config(struct virtio_input *, uint8_t, uint8_t,
+	struct virtio_input_config *);
 
 static struct virtio_ops virtio_input_ops = {
 	"virtio_input",			/* our name */
@@ -174,32 +176,63 @@ static struct virtio_ops virtio_input_ops = {
 static void
 virtio_input_reset(void *vdev)
 {
-	/* to be implemented */
+	struct virtio_input *vi;
+
+	vi = vdev;
+
+	DPRINTF(("vtinput: device reset requested!\n"));
+	vi->ready = false;
+	virtio_reset_dev(&vi->base);
 }
 
 static void
 virtio_input_neg_features(void *vdev, uint64_t negotiated_features)
 {
-	/* to be implemented */
+	struct virtio_input *vi = vdev;
+
+	vi->features = negotiated_features;
 }
 
 static void
 virtio_input_set_status(void *vdev, uint64_t status)
 {
-	/* to be implemented */
+	struct virtio_input *vi = vdev;
+
+	if (status & VIRTIO_CR_STATUS_DRIVER_OK) {
+		if (!vi->ready)
+			vi->ready = true;
+	}
 }
 
 static int
 virtio_input_cfgread(void *vdev, int offset, int size, uint32_t *retval)
 {
-	/* to be implemented */
+	struct virtio_input *vi = vdev;
+	struct virtio_input_config cfg;
+	bool rc;
+
+	rc = virtio_input_get_config(vi, vi->cfg.select,
+		vi->cfg.subsel, &cfg);
+	if (rc)
+		memcpy(retval, (uint8_t *)&cfg + offset, size);
+	else
+		memset(retval, 0, size);
+
 	return 0;
 }
 
 static int
 virtio_input_cfgwrite(void *vdev, int offset, int size, uint32_t val)
 {
-	/* to be implemented */
+	struct virtio_input *vi = vdev;
+
+	if (offset == offsetof(struct virtio_input_config, select))
+		vi->cfg.select = (uint8_t)val;
+	else if (offset == offsetof(struct virtio_input_config, subsel))
+		vi->cfg.subsel = (uint8_t)val;
+	else
+		DPRINTF(("vtinput: write to readonly reg %d\n", offset));
+
 	return 0;
 }
 
@@ -221,6 +254,14 @@ virtio_input_read_event(int fd __attribute__((unused)),
 			void *arg)
 {
 	/* to be implemented */
+}
+
+static bool
+virtio_input_get_config(struct virtio_input *vi, uint8_t select,
+			uint8_t subsel, struct virtio_input_config *cfg)
+{
+	/* to be implemented */
+	return false;
 }
 
 static int

--- a/hw/pci/virtio/virtio_input.c
+++ b/hw/pci/virtio/virtio_input.c
@@ -691,7 +691,24 @@ fail:
 static void
 virtio_input_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 {
-	/* to be implemented */
+	struct virtio_input *vi;
+
+	vi = (struct virtio_input *)dev->arg;
+	if (vi) {
+		pthread_mutex_destroy(&vi->mtx);
+		if (vi->event_queue)
+			free(vi->event_queue);
+		if (vi->mevp)
+			mevent_delete(vi->mevp);
+		if (vi->fd > 0)
+			close(vi->fd);
+		if (vi->evdev)
+			free(vi->evdev);
+		if (vi->serial)
+			free(vi->serial);
+		free(vi);
+		vi = NULL;
+	}
 }
 
 struct pci_vdev_ops pci_ops_virtio_input = {

--- a/include/virtio.h
+++ b/include/virtio.h
@@ -215,6 +215,7 @@ struct vring_used {
 #define	VIRTIO_TYPE_RPMSG	7
 #define	VIRTIO_TYPE_SCSI	8
 #define	VIRTIO_TYPE_9P		9
+#define	VIRTIO_TYPE_INPUT	18
 
 /*
  * ACRN virtio device types


### PR DESCRIPTION
This patchset implemented virtio-input backend driver in acrn device
model based on virtio 1.0 framework.

Properties of host input device are read from evdev character device
driver to service configuration request from FE driver during the device
specific configuration negotiation. The properties include:
- name and devids
- propbit and evbit
- absbit

Input events are polled via mevent and are read from evdev character
device driver when available. A local event queue is implemented to
cache input events utill a SYN event is read. All cached input events
are then sent to guest via virtqueue.

v4 --> v5:
- rename VIRTIO_INPUT_EVENT to VIRTIO_INPUT_EVENT_QUEUE
- rename VIRTIO_INPUT_STATUS to VIRTIO_INPUT_STATUS_QUEUE
- rename INPUT_PACKET_SIZE to VIRTIO_INPUT_PACKET_SIZE
- add description for struct virtio_input_config
- host input device properties are read on demand instead of using a list to
  cache them in advance

v3 --> v4:
- rename VIRTIO_INPUT_DEFAULT_QSIZE to INPUT_PACKET_SIZE
- remove __attribute__((packed)) from struct virtio_input_config
- rename "vtinput" to "virtio_input" in virtio_input_ops
- rename virtio_input_notify_event to virtio_input_notify_event_vq
- rename virtio_input_notify_status to virtio_input_notify_status_vq
- add macro VIRTIO_TYPE_INPUT in virtio.h
- remove EV_SND
- use vq_retchain instead of introduction of a new virtio API

v2 --> v3:
- revise the commit message in 1/6

v1 --> v2:
- pthread_mutex_destroy when failure in virtio_input_init
- pthread_mutex_destroy/mevent_delete/close fd in virtio_input_deinit