### PR TITLE
DM: bug fix in handling signal

### DIFF
--- a/core/main.c
+++ b/core/main.c
@@ -648,6 +648,8 @@ main(int argc, char *argv[])
 	quit_vm_loop = 0;
 	hugetlb = 0;
 
+	if (signal(SIGHUP, sig_handler_term) == SIG_ERR)
+		fprintf(stderr, "cannot register handler for SIGHUP\n");
 	if (signal(SIGINT, sig_handler_term) == SIG_ERR)
 		fprintf(stderr, "cannot register handler for SIGINT\n");
 


### PR DESCRIPTION
With curren code, DM will ignore the SIGHUP signal generated from
SOS reboot that causes DM will not release resource when SOS reboot
occurs.

Signed-off-by: Zheng, Gen <gen.zheng@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>