### PR TITLE
DM: rename acrn_register to acpi_generic_address

### DIFF
--- a/hw/acpi/acpi_pm.c
+++ b/hw/acpi/acpi_pm.c
@@ -172,7 +172,7 @@ void dsdt_write_cst(struct vmctx *ctx, int vcpu_id)
 	int i;
 	uint8_t vcpu_cx_cnt;
 	char *cx_asi;
-	struct acrn_register cx_reg;
+	struct acpi_generic_address cx_reg;
 	struct cpu_cx_data *vcpu_cx_data;
 
 	vcpu_cx_cnt = get_vcpu_cx_cnt(ctx, vcpu_id);

--- a/include/public/acrn_common.h
+++ b/include/public/acrn_common.h
@@ -320,7 +320,7 @@ struct acrn_vm_pci_msix_remap {
 #define SPACE_PLATFORM_COMM     10
 #define SPACE_FFixedHW          0x7F
 
-struct acrn_register {
+struct acpi_generic_address {
 	uint8_t 	space_id;
 	uint8_t 	bit_width;
 	uint8_t 	bit_offset;
@@ -329,7 +329,7 @@ struct acrn_register {
 } __attribute__((aligned(8)));
 
 struct cpu_cx_data {
-	struct acrn_register cx_reg;
+	struct acpi_generic_address cx_reg;
 	uint8_t 	type;
 	uint32_t	latency;
 	uint64_t	power;


### PR DESCRIPTION
The name of acrn_register is too generic, rename to acpi_generic_address
which is more common.

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Kevin Tian <kevin.tian@intel.com>